### PR TITLE
fix: new Date always return year of 1970

### DIFF
--- a/calendar-helper/index.js
+++ b/calendar-helper/index.js
@@ -102,6 +102,13 @@ class CalendarHelper {
 	}
 
 	getPage(m, inputDate) {
+		let dateNumber = this.options.minDate !== null || this.options.maxDate !== null ? Math.min(Math.max(inputDate, this.options.minDate), this.options.maxDate) : null;
+		let date = inputDate 
+		
+		if(dateNumber) {
+			date = new Date(dateNumber);
+		}
+
 		let page = [];
 		this.addHeader(page, m, inputDate);
 		this.addDays(page, m, inputDate);

--- a/calendar-helper/index.js
+++ b/calendar-helper/index.js
@@ -103,11 +103,7 @@ class CalendarHelper {
 
 	getPage(m, inputDate) {
 		let dateNumber = this.options.minDate !== null || this.options.maxDate !== null ? Math.min(Math.max(inputDate, this.options.minDate), this.options.maxDate) : null;
-		let date = inputDate 
-		
-		if(dateNumber) {
-			date = new Date(dateNumber);
-		}
+		let date = dateNumber ? new Date(dateNumber) : inputDate;
 
 		let page = [];
 		this.addHeader(page, m, date);

--- a/calendar-helper/index.js
+++ b/calendar-helper/index.js
@@ -110,8 +110,8 @@ class CalendarHelper {
 		}
 
 		let page = [];
-		this.addHeader(page, m, inputDate);
-		this.addDays(page, m, inputDate);
+		this.addHeader(page, m, date);
+		this.addDays(page, m, date);
 		return page;
 	}
 

--- a/calendar-helper/index.js
+++ b/calendar-helper/index.js
@@ -102,13 +102,9 @@ class CalendarHelper {
 	}
 
 	getPage(m, inputDate) {
-		// I use a math clamp to check if the input date is in range
-		let dateNumber = Math.min(Math.max(inputDate, this.options.minDate), this.options.maxDate);
-		let date = new Date(dateNumber);
-
 		let page = [];
-		this.addHeader(page, m, date);
-		this.addDays(page, m, date);
+		this.addHeader(page, m, inputDate);
+		this.addDays(page, m, inputDate);
 		return page;
 	}
 

--- a/calendar-helper/index.js
+++ b/calendar-helper/index.js
@@ -102,7 +102,8 @@ class CalendarHelper {
 	}
 
 	getPage(m, inputDate) {
-		let dateNumber = this.options.minDate !== null || this.options.maxDate !== null ? Math.min(Math.max(inputDate, this.options.minDate), this.options.maxDate) : null;
+// I use a math clamp to check if the input date is in range
+let dateNumber = this.options.minDate || this.options.maxDate ? Math.min(Math.max(inputDate, this.options.minDate), this.options.maxDate) : null;
 		let date = dateNumber ? new Date(dateNumber) : inputDate;
 
 		let page = [];


### PR DESCRIPTION
This pull request fix the behaviour of getPage code which always return 1970 as year even using new Date() as argument in `calendar.getCalendar()`