### PR TITLE
Fixed bug with february

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,10 @@ class Calendar {
     });
 
     this.bot.action(/calendar-telegram-next-[\d-]+/g, (context) => {
-      let dateString = context.match[0].replace('calendar-telegram-next-', '');
+      let dateString = context.match[0]
+        .replace('calendar-telegram-next-', '')
+        .replace(/-\d+$/, '-01');
+
       let date = new Date(dateString);
       date.setMonth(date.getMonth() + 1);
 


### PR DESCRIPTION
There is an issue with navigating between dates.

Example,

```
const date = new Date('2023-01-30');
console.log(date.getMonth()); // 0
date.setMonth(date.getMonth() + 1);
console.log(date.getMonth()); // 2
```
This issue is currently reproducible in the `master` branch and was fixed in this commit by setting the day of each next requested month to 1.